### PR TITLE
Expose cached values as properties instead of functions

### DIFF
--- a/lib/ecies.js
+++ b/lib/ecies.js
@@ -33,39 +33,41 @@ ECIES.prototype.publicKey = function(publicKey) {
   return this;
 };
 
-ECIES.prototype.Rbuf = function() {
-  if (!this._Rbuf) {
-    var Rpubkey = this._privateKey.publicKey;
-    this._Rbuf = Rpubkey.toDER(true);
-  }
-  return this._Rbuf;
+var cachedProperty = function(name, getter) {
+  var cachedName = '_' + name;
+  Object.defineProperty(ECIES.prototype, name, {
+    configurable: false,
+    enumerable: true,
+    get: function() {
+      var value = this[cachedName];
+      if (!value) {
+        value = this[cachedName] = getter.apply(this);
+      }
+      return value;
+    }
+  });
 };
 
-ECIES.prototype.kEkM = function() {
-  if (!this._kEkM) {
-    var r = this._privateKey.bn;
-    var KB = this._publicKey.point;
-    var P = KB.mul(r);
-    var S = P.getX();
-    var Sbuf = S.toBuffer({size: 32});
-    this._kEkM = Hash.sha512(Sbuf);
-  }
-  return this._kEkM;
-};
+cachedProperty('Rbuf', function() {
+  return this._privateKey.publicKey.toDER(true);
+});
 
-ECIES.prototype.kE = function() {
-  if (!this._kE) {
-    this._kE = this.kEkM().slice(0, 32);
-  }
-  return this._kE;
-};
+cachedProperty('kEkM', function() {
+  var r = this._privateKey.bn;
+  var KB = this._publicKey.point;
+  var P = KB.mul(r);
+  var S = P.getX();
+  var Sbuf = S.toBuffer({size: 32});
+  return Hash.sha512(Sbuf);
+});
 
-ECIES.prototype.kM = function() {
-  if (!this._kM) {
-    this._kM = this.kEkM().slice(32,64);
-  }
-  return this._kM;
-};
+cachedProperty('kE', function() {
+  return this.kEkM.slice(0, 32);
+});
+
+cachedProperty('kM', function() {
+  return this.kEkM.slice(32,64);
+});
 
 // Encrypts the message (String or Buffer).
 // Optional `ivbuf` contains 16-byte Buffer to be used in AES-CBC.
@@ -80,9 +82,9 @@ ECIES.prototype.encrypt = function(message, ivbuf) {
   if (ivbuf === undefined) {
     ivbuf = Hash.sha256hmac(message, this._privateKey.toBuffer()).slice(0,16);
   }
-  var c = AESCBC.encryptCipherkey(message, this.kE(), ivbuf);
-  var d = Hash.sha256hmac(c, this.kM());
-  var encbuf = Buffer.concat([this.Rbuf(), c, d]);
+  var c = AESCBC.encryptCipherkey(message, this.kE, ivbuf);
+  var d = Hash.sha256hmac(c, this.kM);
+  var encbuf = Buffer.concat([this.Rbuf, c, d]);
 
   return encbuf;
 };
@@ -94,9 +96,9 @@ ECIES.prototype.decrypt = function(encbuf) {
   var c = encbuf.slice(33, encbuf.length - 32);
   var d = encbuf.slice(encbuf.length - 32, encbuf.length);
 
-  var d2 = Hash.sha256hmac(c, this.kM());
+  var d2 = Hash.sha256hmac(c, this.kM);
   if (d.toString('hex') !== d2.toString('hex')) throw new Error('Invalid checksum');
-  var messagebuf = AESCBC.decryptCipherkey(c, this.kE());
+  var messagebuf = AESCBC.decryptCipherkey(c, this.kE);
 
   return messagebuf;
 };


### PR DESCRIPTION
Tested that it has no big performance hit because of an extra scope with this:

```
var ECIES = require('./');
var bitcore = require('bitcore');

var aliceKey = new bitcore.PrivateKey();
var bobKey = new bitcore.PrivateKey();

var alice = ECIES()
  .privateKey(aliceKey)
  .publicKey(bobKey.publicKey);
var bob = ECIES()
  .privateKey(bobKey)
  .publicKey(aliceKey.publicKey);

var message = 'some secret message';

var encrypted, decrypted;

var time = new Date().getTime();
for (var i = 0; i < 1000; i++) {
  encrypted = alice.encrypt(message);
  decrypted = bob.decrypt(encrypted);
}

console.log('Took', new Date().getTime() - time, 'ms');
```
